### PR TITLE
Remove module

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.0
+current_version = 1.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ A Terraform module to create DNS-validated certificates using ACM
 <!-- BEGIN TFDOCS -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | ~> 0.12.0 |
+No requirements.
 
 ## Providers
 
@@ -20,7 +18,6 @@ A Terraform module to create DNS-validated certificates using ACM
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | certificate\_transparency\_logging\_preference | Value to apply to the certificate transparency logging preference for the ACM certificate | `string` | `"ENABLED"` | no |
-| create\_acm\_certificate | Toggle to enable/disable the ACM certificate creation | `bool` | `true` | no |
 | domain\_name | Domain name to use for the ACM certificate | `string` | `""` | no |
 | subject\_alternative\_names | Subject alternative names to associate with the ACM certificate | `list(string)` | `[]` | no |
 | tags | Map of tags to apply to all resources that support tags | `map(string)` | `{}` | no |

--- a/tests/create_certificate/main.tf
+++ b/tests/create_certificate/main.tf
@@ -1,3 +1,7 @@
+provider aws {
+  region = "us-east-1"
+}
+
 locals {
   test_id = length(data.terraform_remote_state.prereq.outputs) > 0 ? data.terraform_remote_state.prereq.outputs.random_string.result : ""
 

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -444,6 +444,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200109152110-61a87790db17/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -486,6 +487,7 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -615,6 +617,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tests/no_create_certificate/main.tf
+++ b/tests/no_create_certificate/main.tf
@@ -1,9 +1,0 @@
-module "create_certificate" {
-  source = "../../"
-
-  create_acm_certificate = false
-}
-
-output "create_certificate" {
-  value = module.create_certificate
-}

--- a/variables.tf
+++ b/variables.tf
@@ -4,16 +4,9 @@ variable "certificate_transparency_logging_preference" {
   default     = "ENABLED"
 }
 
-variable "create_acm_certificate" {
-  description = "Toggle to enable/disable the ACM certificate creation"
-  type        = bool
-  default     = true
-}
-
 variable "domain_name" {
   description = "Domain name to use for the ACM certificate"
   type        = string
-  default     = ""
 }
 
 variable "subject_alternative_names" {


### PR DESCRIPTION
results of make test:
FAIL    terraform-aws-tardigrade-acm/tests      6.176s
make: *** [terratest/test] Error 1

Error: no matching Route53Zone found

My understanding: this is because the AWS account does not have resources configured to create the cert but I believe the code is correct. Please correct me if I'm wrong